### PR TITLE
LoadScreen obsolete and flexible queue size

### DIFF
--- a/src/eez/flow/lvgl_api.cpp
+++ b/src/eez/flow/lvgl_api.cpp
@@ -69,12 +69,6 @@ static void executeLvglAction(int actionIndex) {
     g_actions[actionIndex](0);
 }
 
-extern "C" void loadScreen(int index) {
-    g_currentScreen = index;
-    lv_obj_t *screen = getLvglObjectFromIndex(index);
-    lv_scr_load_anim(screen, LV_SCR_LOAD_ANIM_FADE_IN, 200, 0, false);
-}
-
 #if !defined(EEZ_LVGL_SCREEN_STACK_SIZE)
 #define EEZ_LVGL_SCREEN_STACK_SIZE 10
 #endif

--- a/src/eez/flow/lvgl_api.h
+++ b/src/eez/flow/lvgl_api.h
@@ -50,8 +50,6 @@ bool eez_flow_is_stopped();
 
 extern int16_t g_currentScreen;
 
-void loadScreen(int index);
-
 int16_t eez_flow_get_current_screen();
 void eez_flow_set_screen(int16_t screenId, lv_scr_load_anim_t animType, uint32_t speed, uint32_t delay);
 void eez_flow_push_screen(int16_t screenId, lv_scr_load_anim_t animType, uint32_t speed, uint32_t delay);

--- a/src/eez/flow/queue.cpp
+++ b/src/eez/flow/queue.cpp
@@ -17,7 +17,10 @@
 namespace eez {
 namespace flow {
 
-static const unsigned QUEUE_SIZE = 1000;
+#if !defined(EEZ_FLOW_QUEUE_SIZE)
+#define EEZ_FLOW_QUEUE_SIZE 1000
+#endif
+static const unsigned QUEUE_SIZE = EEZ_FLOW_QUEUE_SIZE;
 static struct {
 	FlowState *flowState;
 	unsigned componentIndex;


### PR DESCRIPTION
While looking into the memory usage I noticed the loadScreen function is obsolete now.
Also make the queue size flexible