### PR TITLE
function added to keep track of maximum used flow queue size.

### DIFF
--- a/src/eez/flow/queue.cpp
+++ b/src/eez/flow/queue.cpp
@@ -28,12 +28,14 @@ static struct {
 } g_queue[QUEUE_SIZE];
 static unsigned g_queueHead;
 static unsigned g_queueTail;
+static unsigned g_queueMax;
 static bool g_queueIsFull = false;
 unsigned g_numContinuousTaskInQueue;
 
 void queueReset() {
 	g_queueHead = 0;
 	g_queueTail = 0;
+	g_queueMax  = 0;
 	g_queueIsFull = false;
     g_numContinuousTaskInQueue = 0;
 }
@@ -53,6 +55,10 @@ size_t getQueueSize() {
 	return QUEUE_SIZE - g_queueHead + g_queueTail;
 }
 
+size_t getMaxQueueSize() {
+	return g_queueMax;
+}
+
 bool addToQueue(FlowState *flowState, unsigned componentIndex, int sourceComponentIndex, int sourceOutputIndex, int targetInputIndex, bool continuousTask) {
 	if (g_queueIsFull) {
         throwError(flowState, componentIndex, "Execution queue is full\n");
@@ -68,6 +74,9 @@ bool addToQueue(FlowState *flowState, unsigned componentIndex, int sourceCompone
 	if (g_queueHead == g_queueTail) {
 		g_queueIsFull = true;
 	}
+
+	size_t queueSize = getQueueSize();
+	g_queueMax = g_queueMax < queueSize ? queueSize : g_queueMax;
 
     if (!continuousTask) {
         ++g_numContinuousTaskInQueue;

--- a/src/eez/flow/queue.h
+++ b/src/eez/flow/queue.h
@@ -17,6 +17,7 @@ namespace flow {
 
 void queueReset();
 size_t getQueueSize();
+size_t getMaxQueueSize();
 extern unsigned g_numContinuousTaskInQueue;
 bool addToQueue(FlowState *flowState, unsigned componentIndex,
     int sourceComponentIndex, int sourceOutputIndex, int targetInputIndex,


### PR DESCRIPTION
Added function and variable that keeps track of a high water mark of the queue size. This is needed if you want to tune the queue size on low memory systems.