### PR TITLE
Fix 'not interpreted with this event code' warnings.

### DIFF
--- a/src/eez/flow/lvgl_api.cpp
+++ b/src/eez/flow/lvgl_api.cpp
@@ -190,7 +190,9 @@ extern "C" void flowPropagateValueLVGLEvent(void *flowState, unsigned componentI
 
     int32_t rotaryDiff = 0;
 #if LVGL_VERSION_MAJOR >= 9
-    rotaryDiff = lv_event_get_rotary_diff(event);
+    if (lv_event_get_code(event) == LV_EVENT_ROTARY) {
+        rotaryDiff = lv_event_get_rotary_diff(event);
+    }
 #endif
 
     eez::flow::propagateValue(


### PR DESCRIPTION
lv_event_get_rotary_diff should only be called when the event is a rotary event. Otherwise the function  will generate a warning. Cluttering logs...

![image](https://github.com/user-attachments/assets/626930c4-6321-4cb0-a7ba-da48feb0ddcb)
