### PR TITLE
configurable tick max duration and corresponding debug counter

### DIFF
--- a/src/eez/flow/flow.cpp
+++ b/src/eez/flow/flow.cpp
@@ -45,7 +45,12 @@ namespace flow {
 uint32_t g_wasmModuleId = 0;
 #endif
 
-static const uint32_t FLOW_TICK_MAX_DURATION_MS = 5;
+#if !defined(EEZ_FLOW_TICK_MAX_DURATION_MS)
+#define EEZ_FLOW_TICK_MAX_DURATION_MS 5
+#endif
+static const uint32_t FLOW_TICK_MAX_DURATION_MS = EEZ_FLOW_TICK_MAX_DURATION_MS;
+
+static unsigned g_tick_max_duration_count = 0;
 
 int g_selectedLanguage = 0;
 FlowState *g_firstFlowState;
@@ -135,6 +140,7 @@ void tick() {
 
         if ((i + 1) % 5 == 0) {
             if (millis() - startTickCount >= FLOW_TICK_MAX_DURATION_MS) {
+                g_tick_max_duration_count++;
                 break;
             }
         }
@@ -166,6 +172,10 @@ void doStop() {
 
 bool isFlowStopped() {
     return g_isStopped;
+}
+
+unsigned getTickMaxDurationCounter() {
+    return g_tick_max_duration_count;
 }
 
 #if EEZ_OPTION_GUI

--- a/src/eez/flow/flow.cpp
+++ b/src/eez/flow/flow.cpp
@@ -96,6 +96,8 @@ void tick() {
 
 	uint32_t startTickCount = millis();
 
+    visitWatchList();
+
     auto queueSizeAtTickStart = getQueueSize();
 
     for (size_t i = 0; i < queueSizeAtTickStart || g_numNonContinuousTaskInQueue > 0; i++) {
@@ -145,8 +147,6 @@ void tick() {
             }
         }
 	}
-
-    visitWatchList();
 
 	finishToDebuggerMessageHook();
 }

--- a/src/eez/flow/flow.h
+++ b/src/eez/flow/flow.h
@@ -31,6 +31,7 @@ void tick();
 void stop();
 
 bool isFlowStopped();
+unsigned getTickMaxDurationCounter();
 
 #if EEZ_OPTION_GUI
 FlowState *getPageFlowState(Assets *assets, int16_t pageIndex, const WidgetCursor &widgetCursor);


### PR DESCRIPTION
Just like queue size I've made the max duration compile time configurable.

For debugging / performance insight purposes I've also included a counter and a readout function to get insight how often this is happening.

It helped me to get insight when pushing to higher update rates of measurement showing on display and what happens during screen changes.