### PR TITLE
moved visitWatchList before queue loop in tick().

### DIFF
--- a/src/eez/flow/flow.cpp
+++ b/src/eez/flow/flow.cpp
@@ -91,6 +91,8 @@ void tick() {
 
 	uint32_t startTickCount = millis();
 
+    visitWatchList();
+
     auto queueSizeAtTickStart = getQueueSize();
 
     for (size_t i = 0; i < queueSizeAtTickStart || g_numNonContinuousTaskInQueue > 0; i++) {
@@ -139,8 +141,6 @@ void tick() {
             }
         }
 	}
-
-    visitWatchList();
 
 	finishToDebuggerMessageHook();
 }


### PR DESCRIPTION
This will process the watchlist before the queue in ui_tick().. The effect is that actions triggered by a watch will not wait until the next tick to be processed. 