### PR TITLE
bugfix - inc/dec Counter for Flowstate does not check for null

### DIFF
--- a/src/eez/flow/private.cpp
+++ b/src/eez/flow/private.cpp
@@ -270,6 +270,9 @@ FlowState *initPageFlowState(Assets *assets, int flowIndex, FlowState *parentFlo
 }
 
 void incRefCounterForFlowState(FlowState *flowState) {
+    if (!flowState) {
+        return;
+    }
     flowState->refCounter++;
     for (auto parent = flowState->parentFlowState; parent; parent = parent->parentFlowState) {
         parent->refCounter++;
@@ -277,6 +280,9 @@ void incRefCounterForFlowState(FlowState *flowState) {
 }
 
 void decRefCounterForFlowState(FlowState *flowState) {
+    if (!flowState) {
+        return;
+    }
     flowState->refCounter--;
     for (auto parent = flowState->parentFlowState; parent; parent = parent->parentFlowState) {
         parent->refCounter--;


### PR DESCRIPTION
Added null check for inc/dec-RefCounterForFlowState functions  causes crash

PC : 0x420bbfcb PS : 0x00060930 A0 : 0x82010657 A1 : 0x3fcd0510
--- 0x420bbfcb: eez::flow::decRefCounterForFlowState(eez::flow::FlowState*) at /workspaces/xxx/components/eez-framework/src/eez/flow/private.cpp:280

A2 : 0x00000000 A3 : 0x0000000c A4 : 0x00000000 A5 : 0x0000ff00
A6 : 0x3fcac4fc A7 : 0x00000030 A8 : 0x00000000 A9 : 0x00000004
A10 : 0x3fcd0500 A11 : 0x3fcac4fc A12 : 0x3c0e81a8 A13 : 0x3fcd0500
A14 : 0x3fcd04e0 A15 : 0x00000000 SAR : 0x0000001f EXCCAUSE: 0x0000001c
EXCVADDR: 0x00000018 LBEG : 0x40056f5c LEND : 0x40056f72 LCOUNT : 0xffffffff
--- 0x40056f5c: memcpy in ROM
--- 0x40056f72: memcpy in ROM

Backtrace: 0x420bbfc8:0x3fcd0510 0x42010654:0x3fcd0530 0x4201449a:0x3fcd0550 0x4200f217:0x3fcd0580 0x4200ab43:0x3fcd05a0 0x4200aaa4:0x3fcd05c0
--- 0x420bbfc8: eez::flow::decRefCounterForFlowState(eez::flow::FlowState*) at /workspaces/xxx/components/eez-framework/src/eez/flow/private.cpp:279
--- 0x42010654: eez::flow::removeNextTaskFromQueue() at /workspaces/xxx/components/eez-framework/src/eez/flow/queue.cpp:105
--- 0x4201449a: eez::flow::tick() at /workspaces/xxx/components/eez-framework/src/eez/flow/flow.cpp:112
--- 0x4200f217: eez_flow_tick at /workspaces/xxx/components/eez-framework/src/eez/flow/lvgl_api.cpp:306
--- 0x4200ab43: ui_tick at /workspaces/xxx/main/ui/ui.c:1203